### PR TITLE
Change restore order of operations

### DIFF
--- a/lib/stellar-core-backup/job.rb
+++ b/lib/stellar-core-backup/job.rb
@@ -133,7 +133,7 @@ module StellarCoreBackup
                   raise StandardError
                 end
               end
-              StellarCoreBackup::Utils.cleanbucket(@fs_restore.core_data_dir)
+              StellarCoreBackup::Utils.cleanbucket(@fs_restore.core_data_dir) if @clean
               @fs_restore.restore(@backup_archive)
               @db_restore.restore()
 


### PR DESCRIPTION
Checks whether the bucket directory is clean or the --clean flag has
been selected before any operations continue.

If --clean has been selected this operation is now done immediately
prior to the restore which wasn't the case earlier.